### PR TITLE
Disable generated attribution

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,10 @@ sylliptor-feedback/
 reports/
 qa_reports/
 
-# Claude Code local config
-.claude/
+# Local tool config
+.claude/*
+!.claude/
+!.claude/settings.json
 
 # OS / IDE
 .DS_Store


### PR DESCRIPTION
Adds repository settings that disable generated commit and PR attribution for future app sessions.