### PR TITLE
fix(sandbox): remediate CVE-2026-14257

### DIFF
--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -21,6 +21,11 @@ on:
           - dev
           - base
           - server
+      release_tag:
+        description: Optional existing release image tag to repair from the selected ref.
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -183,7 +188,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+          release_tag="${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || '' }}"
+          if [[ -n "${release_tag}" ]]; then
+            if [[ ! "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+              echo "Invalid release tag: ${release_tag}" >&2
+              exit 1
+            fi
+            if ! git ls-remote --exit-code --tags origin "refs/tags/${release_tag}" >/dev/null; then
+              echo "Release tag does not exist: ${release_tag}" >&2
+              exit 1
+            fi
+            version="${release_tag}"
+          elif [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             version="${GITHUB_REF_NAME}"
           else
             version="${GITHUB_SHA::12}"
@@ -212,8 +228,10 @@ jobs:
             type=raw,value=${{ matrix.variant }}
             type=sha,format=short,prefix=${{ matrix.variant }}-
             type=ref,event=tag,prefix=${{ matrix.variant }}-
+            type=raw,value=${{ matrix.variant }}-${{ inputs.release_tag }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.release_tag != '' }}
             type=raw,value=latest,enable=${{ matrix.variant == env.DEFAULT_VARIANT }}
             type=ref,event=tag,enable=${{ matrix.variant == env.DEFAULT_VARIANT }}
+            type=raw,value=${{ inputs.release_tag }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.release_tag != '' && matrix.variant == env.DEFAULT_VARIANT }}
 
       - name: Build sandbox image
         id: build

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -65,6 +65,7 @@ ARG NODE_MAJOR=24
 # Keep npm ahead of the NodeSource package's bundled npm when scanner-actionable
 # transitive npm dependencies receive security fixes.
 ARG NPM_VERSION=11.18.0
+ARG NPM_BRACE_EXPANSION_VERSION=5.0.8
 ARG TARGETARCH
 ARG GO_VERSION=1.26.5
 ARG GO_LINUX_AMD64_SHA256=5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053
@@ -105,6 +106,17 @@ RUN install -d -m 0755 /etc/apt/keyrings; \
     echo "APT pin: ${package}=${version}"; \
     apt-get install -y --no-install-recommends "${package}=${version}"; \
     npm install -g "npm@${NPM_VERSION}"; \
+    npm_root="$(npm root -g)"; \
+    npm_override_dir="$(mktemp -d)"; \
+    npm install --prefix "${npm_override_dir}" --no-save --ignore-scripts \
+        "brace-expansion@${NPM_BRACE_EXPANSION_VERSION}"; \
+    rm -rf "${npm_root}/npm/node_modules/brace-expansion"; \
+    cp -a "${npm_override_dir}/node_modules/brace-expansion" \
+        "${npm_root}/npm/node_modules/brace-expansion"; \
+    rm -rf "${npm_override_dir}"; \
+    installed_brace_expansion="$(node -p \
+        "require('${npm_root}/npm/node_modules/brace-expansion/package.json').version")"; \
+    test "${installed_brace_expansion}" = "${NPM_BRACE_EXPANSION_VERSION}"; \
     npm cache clean --force; \
     apt-mark manual "${package}"; \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

- Replace npm's bundled `brace-expansion` 5.0.7 with fixed version 5.0.8 inside dev/server sandbox images.
- Verify the installed nested package version during the Docker build.
- Add an explicit, validated `release_tag` workflow-dispatch input so affected `v0.11.2` image tags can be rebuilt from this security-fix commit without moving the Git release tag.

## Context

The `v0.11.2` Python release workflow and main CI are green. The tagged sandbox workflow built the images but Trivy blocked dev/server publication signing on `CVE-2026-14257`, a high-severity memory-exhaustion issue in `brace-expansion` through 5.0.7. npm 11.18.0 and the current npm 12.0.1 package both bundle 5.0.7, so an explicit nested-package replacement is required.

## Validation

- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m pytest -q tests/test_release_smoke.py` (3 passed)
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/sandbox-image.yml`
- npm bundle simulation: replacement reports 5.0.8 and npm reports 11.18.0

After merge, dispatch `sandbox-image` from this commit with `release_tag=v0.11.2` and verify the build, Trivy scan, provenance, signatures, and runtime smoke jobs.