### PR TITLE
feat: render status and mode changes on the dedicated trace channel

### DIFF
--- a/src/alysis_code/surface/rich_surface.py
+++ b/src/alysis_code/surface/rich_surface.py
@@ -1024,7 +1024,8 @@ class RichSurface:
         step: int | None = None,
         step_budget: int | None = None,
     ) -> None:
-        # TODO: dedicated rendering for status_update.
+        if self._trace_level == "off":
+            return
         parts: list[str] = []
         if model:
             parts.append(f"model={model}")
@@ -1043,11 +1044,22 @@ class RichSurface:
             parts.append(f"cached={cached_tokens}")
         if cost_usd is not None:
             parts.append(f"cost=${cost_usd:.6f}")
-        self._emit_event_info("Status: " + (" · ".join(parts) if parts else "updated"))
+        self._emit_trace_line(
+            " · ".join(parts) if parts else "updated",
+            style=_STYLE_META,
+            prefix="Status: ",
+            prefix_style=_STYLE_META,
+        )
 
     def emit_mode_changed(self, mode: str) -> None:
-        # TODO: dedicated rendering for mode_changed.
-        self._emit_event_info(f"Mode: {mode}")
+        if self._trace_level == "off":
+            return
+        self._emit_trace_line(
+            mode,
+            style=_STYLE_META,
+            prefix="Mode: ",
+            prefix_style=_STYLE_META,
+        )
 
     def reset_streamed_assistant(self) -> None:
         # Classic terminal output cannot be unprinted; mark the restart so the

--- a/tests/test_surface_events.py
+++ b/tests/test_surface_events.py
@@ -199,3 +199,59 @@ def test_rich_surface_accepts_all_structured_event_methods() -> None:
 def test_noop_and_hidden_surfaces_accept_all_structured_event_methods() -> None:
     _call_all_emit_methods(NoopSurface())
     _call_all_emit_methods(HiddenApprovalSurface(None))
+
+
+def _rich_surface_with_buffer() -> tuple[RichSurface, io.StringIO]:
+    buffer = io.StringIO()
+    return RichSurface(console=Console(file=buffer, force_terminal=False)), buffer
+
+
+def test_rich_surface_status_update_renders_dedicated_trace_line() -> None:
+    surface, buffer = _rich_surface_with_buffer()
+
+    surface.emit_status_update(
+        tokens_in=10,
+        tokens_out=5,
+        cached_tokens=2,
+        cost_usd=0.001,
+        mode="review",
+        model="test-model",
+        step=1,
+        step_budget=4,
+    )
+
+    rendered = buffer.getvalue()
+    assert "Status: " in rendered
+    assert "model=test-model" in rendered
+    assert "mode=review" in rendered
+    assert "step=1/4" in rendered
+    assert "in=10" in rendered
+    assert "out=5" in rendered
+    assert "cached=2" in rendered
+    assert "cost=$0.001000" in rendered
+
+
+def test_rich_surface_status_update_without_fields_renders_updated() -> None:
+    surface, buffer = _rich_surface_with_buffer()
+
+    surface.emit_status_update()
+
+    assert "Status: updated" in buffer.getvalue()
+
+
+def test_rich_surface_mode_changed_renders_dedicated_trace_line() -> None:
+    surface, buffer = _rich_surface_with_buffer()
+
+    surface.emit_mode_changed("auto")
+
+    assert "Mode: auto" in buffer.getvalue()
+
+
+def test_rich_surface_status_and_mode_suppressed_when_trace_off() -> None:
+    surface, buffer = _rich_surface_with_buffer()
+    surface.set_trace_level("off")
+
+    surface.emit_status_update(model="test-model")
+    surface.emit_mode_changed("auto")
+
+    assert buffer.getvalue() == ""


### PR DESCRIPTION
Routes RichSurface.emit_status_update and emit_mode_changed through _emit_trace_line with Status:/Mode: prefixes instead of the generic thinking channel.

- Visible terminal text is unchanged (same Status:/Mode: lines).
- trace-level off still suppresses both events.
- Repeated identical lines now dedupe via the shared trace-line key, consistent with all other trace output.
- Removes the two TODOs in rich_surface.py.

Verification: new tests in tests/test_surface_events.py (prefixed rendering, empty-status fallback, trace-off suppression); surface suite 89 passed; ruff check and format clean.