### PR TITLE
refactor: resolve failure-category-audit TODOs via shared classifier

### DIFF
--- a/src/alysis_code/merge_conflict_reviewer.py
+++ b/src/alysis_code/merge_conflict_reviewer.py
@@ -19,6 +19,7 @@ from .config import (
     resolve_role_temperature,
 )
 from .execution_shared import safe_task_file_component
+from .failure_category import classify_failure_category
 from .forge import RunPaths, ensure_execution_dirs, now_iso
 from .git_safe import build_git_cmd
 from .llm.base import ChatClient
@@ -84,6 +85,7 @@ class ConflictReviewOutcome:
     skipped_reason: str | None
     request_retry_count: int = 0
     request_retry_state: str = _REQUEST_RETRY_STATE_NONE
+    failure_category: str | None = None
 
 
 @dataclass(frozen=True)
@@ -285,8 +287,6 @@ def _request_conflict_review_response(
         except LLMError as e:
             retryable = _is_retryable_conflict_review_request_error(e)
             if not retryable or attempt >= _CONFLICT_REVIEW_TRANSIENT_REQUEST_MAX_ATTEMPTS:
-                # TODO(failure-category-audit): default=implementation_failed,
-                # site=merge conflict reviewer retry exhaustion outside Forge result trend, see failure_category.py
                 raise _attach_conflict_review_retry_details(
                     e,
                     retry_count=retry_count,
@@ -662,6 +662,7 @@ def review_merge_conflict(
             skipped_reason=reason,
             request_retry_count=request_retry_count,
             request_retry_state=retry_state,
+            failure_category=classify_failure_category(e).value,
         )
     except (ValueError, json.JSONDecodeError) as e:
         reason = f"review failed: {e}"

--- a/src/alysis_code/swarm_worker.py
+++ b/src/alysis_code/swarm_worker.py
@@ -1856,9 +1856,7 @@ def run_task_worker(
         agent_exception_error = f"agent raised: {agent_exception_summary}"
         run_err = f"{agent_exception_error}; {run_err}" if run_err else agent_exception_error
     if not success and failure_category is None:
-        # TODO(failure-category-audit): default=implementation_failed,
-        # site=swarm_worker generic failure result, see failure_category.py
-        failure_category = FailureCategory.IMPLEMENTATION_FAILED
+        failure_category = classify_failure_category(agent_exception_summary)
 
     if interrupted:
         summary = (

--- a/tests/test_failure_category_classify.py
+++ b/tests/test_failure_category_classify.py
@@ -83,6 +83,14 @@ def test_classify_failure_category(error: Exception, expected: FailureCategory) 
     assert classify_failure_category(error) is expected
 
 
+def test_classify_missing_or_blank_signal_defaults_to_implementation_failed() -> None:
+    # The swarm worker resolves its generic failure default through this
+    # classifier; absent or content-free signals must stay implementation-side.
+    assert classify_failure_category(None) is FailureCategory.IMPLEMENTATION_FAILED
+    assert classify_failure_category("") is FailureCategory.IMPLEMENTATION_FAILED
+    assert classify_failure_category("   ") is FailureCategory.IMPLEMENTATION_FAILED
+
+
 def test_classify_never_returns_legacy_literal() -> None:
     # The old hardcoded "llm_error" string is not a real category and must never appear.
     category = classify_failure_category(Exception("LLM error 400: bad request"))

--- a/tests/test_merge_conflict_reviewer.py
+++ b/tests/test_merge_conflict_reviewer.py
@@ -408,6 +408,68 @@ def test_review_merge_conflict_retry_exhaustion_stays_skipped(tmp_path: Path, mo
     )
 
 
+def test_review_merge_conflict_retry_exhaustion_carries_provider_category(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    paths = create_plan_run(repo)
+
+    class FakeClient:
+        def __init__(self, **_kwargs) -> None:  # type: ignore[no-untyped-def]
+            pass
+
+        def chat(self, **_kwargs):  # type: ignore[no-untyped-def]
+            raise LLMError("LLM request failed: ReadTimeout")
+
+    monkeypatch.setattr(
+        "alysis_code.merge_conflict_reviewer.OpenAICompatClient",
+        FakeClient,
+    )
+
+    outcome = review_merge_conflict(
+        paths=paths,
+        task={"id": "T01", "title": "Resolve merge conflict"},
+        cfg=AppConfig(model="test-model"),
+        api_key_override="k",
+        context={"unmerged_files": ["src/x.py"]},
+    )
+
+    assert outcome.review_json is None
+    assert outcome.failure_category == "provider_unavailable"
+
+
+def test_review_merge_conflict_auth_failure_carries_provider_error_category(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    paths = create_plan_run(repo)
+
+    class FakeClient:
+        def __init__(self, **_kwargs) -> None:  # type: ignore[no-untyped-def]
+            pass
+
+        def chat(self, **_kwargs):  # type: ignore[no-untyped-def]
+            raise LLMError("LLM error 401: invalid_api_key")
+
+    monkeypatch.setattr(
+        "alysis_code.merge_conflict_reviewer.OpenAICompatClient",
+        FakeClient,
+    )
+
+    outcome = review_merge_conflict(
+        paths=paths,
+        task={"id": "T01", "title": "Resolve merge conflict"},
+        cfg=AppConfig(model="test-model"),
+        api_key_override="k",
+        context={"unmerged_files": ["src/x.py"]},
+    )
+
+    assert outcome.review_json is None
+    assert outcome.failure_category == "provider_error"
+
+
 def test_review_merge_conflict_does_not_retry_nontransient_request_error(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
Resolves the two TODO(failure-category-audit) sites with the audit's own vocabulary instead of hardcoded defaults.

- swarm_worker: the generic failure default now goes through classify_failure_category over the agent exception summary, so provider-side worker deaths (timeouts, throttling, 5xx) are categorized instead of lumped into implementation_failed. Absent signals still fall through to implementation_failed.
- merge_conflict_reviewer: ConflictReviewOutcome gains a failure_category field, set from classify_failure_category on the LLMError path (provider_unavailable / provider_error); removes the TODO.

Verification: new tests pinning the None/blank default and both reviewer outcome categories; related suites pass (reviewer, classify, swarm worker/diagnostics, forge review). Note: test_run_task_worker_mirrors_allocates_and_passes_asset_tools fails identically on the clean tree (pre-existing, unrelated context-pack assertion). ruff check and format clean.