### PR TITLE
chore: add Python 3.13 to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
         include:
           - {"python-version":"3.11"}
           - {"python-version":"3.12"}
+          - {"python-version":"3.13"}
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
CI tests 3.11/3.12 while requires-python permits >=3.11, leaving 3.13 uncovered. One-line matrix addition (fail-fast is already false, so a 3.13-only regression surfaces without blocking the other legs).

Verification: clean install on 3.13.12, full suite run (9324 passed). The 20 failures observed reproduce identically on 3.14 and the clean tree (diffed failure sets match) - pre-existing and environmental, unrelated to this change.