### PR TITLE
Verify public sandbox image access and refresh runtime dependencies

### DIFF
--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -50,6 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      actions: read
       contents: read
     outputs:
       release_tag: ${{ steps.source.outputs.release_tag }}
@@ -98,6 +99,26 @@ jobs:
             echo "source_date_epoch=$(git show -s --format=%ct HEAD)"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Check the release approval environment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! gh api "repos/${GITHUB_REPOSITORY}/environments/sandbox-release" > sandbox-release-policy.json; then
+            echo "Configure the sandbox-release environment before publishing; see docs/RELEASING.md." >&2
+            exit 1
+          fi
+          if ! jq -e '
+            any(.protection_rules[]?;
+              .type == "required_reviewers"
+              and .prevent_self_review == true
+              and (.reviewers | length) > 0)
+          ' sandbox-release-policy.json > /dev/null; then
+            echo "sandbox-release must require a maintainer review and prevent self-review." >&2
+            exit 1
+          fi
+
   build-scan-pr:
     name: build, scan, and smoke dev (pr)
     if: github.event_name == 'pull_request'
@@ -139,6 +160,7 @@ jobs:
         id: trivy
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
+          version: "0.74.0"
           image-ref: alysis-sandbox-pr:${{ github.sha }}
           format: sarif
           output: trivy-pr-dev-amd64.sarif
@@ -317,6 +339,7 @@ jobs:
           TRIVY_PLATFORM: linux/amd64
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
+          version: "0.74.0"
           image-ref: ${{ steps.platforms.outputs.amd64_ref }}
           format: sarif
           output: trivy-${{ matrix.variant }}-amd64.sarif
@@ -330,10 +353,12 @@ jobs:
 
       - name: Scan linux/arm64 candidate manifest
         id: trivy-arm64
+        if: ${{ !cancelled() && steps.platforms.outcome == 'success' }}
         env:
           TRIVY_PLATFORM: linux/arm64
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
+          version: "0.74.0"
           image-ref: ${{ steps.platforms.outputs.arm64_ref }}
           format: sarif
           output: trivy-${{ matrix.variant }}-arm64.sarif
@@ -378,7 +403,7 @@ jobs:
         if: matrix.variant == 'dev'
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
-          version: "0.11.23"
+          version: "0.12.13"
           enable-cache: true
           cache-dependency-glob: uv.lock
 
@@ -411,11 +436,12 @@ jobs:
           category: trivy-sandbox-${{ matrix.variant }}-arm64
 
       - name: Upload Trivy SARIF artifacts
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: trivy-${{ matrix.variant }}-${{ needs.validate-source.outputs.sha12 }}-sarif
           path: trivy-${{ matrix.variant }}-*.sarif
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 30
 
       - name: Attest candidate build provenance
@@ -518,6 +544,11 @@ jobs:
       contents: read
       packages: read
     steps:
+      - name: Checkout exact source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -530,6 +561,15 @@ jobs:
           pattern: sandbox-candidate-*-${{ github.sha }}
           path: candidate-records
           merge-multiple: true
+
+      - name: Verify anonymous access before promotion
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq -er '.image + "@" + .digest' candidate-records/*.json > candidate-images.txt
+          mapfile -t images < candidate-images.txt
+          test "${#images[@]}" -eq 3
+          bash scripts/sandbox/check-public-images.sh "${images[@]}"
 
       - name: Verify complete records, immutable digests, signatures, and attestations
         env:
@@ -664,6 +704,11 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Checkout exact source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -811,6 +856,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          : > promoted-images.txt
           mapfile -t records < <(find candidate-records -maxdepth 1 -type f -name '*.json' -print | sort)
           for record in "${records[@]}"; do
             image="$(jq -r '.image' "${record}")"
@@ -845,7 +891,18 @@ jobs:
             fi
 
             docker buildx imagetools create "${tags[@]}" "${image}@${digest}"
+            for ((i=1; i<${#tags[@]}; i+=2)); do
+              printf '%s\n' "${tags[i]}" >> promoted-images.txt
+            done
           done
+
+      - name: Verify anonymous pulls of promoted images
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t images < promoted-images.txt
+          test "${#images[@]}" -ge 3
+          bash scripts/sandbox/check-public-images.sh --pull "${images[@]}"
 
       - name: Write promotion summary
         env:
@@ -864,4 +921,5 @@ jobs:
             echo "- immutable suffix: ${SHA12}"
             echo "- release tag: ${RELEASE_TAG:-none}"
             echo "- moving tags promoted: ${PUBLISH_MOVING_TAGS}"
+            echo "- anonymous pulls: verified for every promoted alias on linux/amd64 and linux/arm64"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -51,6 +51,7 @@ scans, signs, attests, and smoke-tests each supported image variant before promo
 
 Before tagging, confirm that the protected `sandbox-release` environment has required reviewers,
 self-review prevention, and deployment restrictions for `main` and `sandbox-v*` tags.
+The workflow checks that reviewers and self-review prevention are configured before building.
 
 Create and push the tag:
 
@@ -69,6 +70,62 @@ docker buildx imagetools inspect ghcr.io/alysisai/alysis-sandbox:dev
 
 The workflow file is the authoritative description of image variants, signing, provenance, SBOM,
 and promotion checks.
+
+### First publication and missing-image recovery
+
+The CLI and sandbox have separate releases. Updating the image name in source or merging a PR
+does not publish an image. PR jobs build locally without publishing. Rerunning an old Sylliptor
+workflow also uses that run's old source and image name.
+
+After merging reviewed changes into the public repository's default branch and configuring
+`sandbox-release`, start a new run with moving tags enabled:
+
+```bash
+gh workflow run sandbox-image.yml --repo AlysisAi/alysis-code --ref main \
+  -f default_variant=dev -f publish_moving_tags=true
+```
+
+Without `publish_moving_tags=true`, a manual run does not create or update the `:base`, `:dev`,
+`:server`, and `:latest` references used by normal installations. A `sandbox-v*` tag release does
+update those references.
+
+For the first publication, the package owner must check **Packages > alysis-sandbox > Package
+settings**, set visibility to **Public**, and grant this repository Actions access. New GHCR
+packages default to private; a public source repository does not establish anonymous package
+access. See [GitHub's package visibility guide](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility).
+
+The workflow checks anonymous candidate access before changing consumer tags. If that check
+fails because the new package is private, correct its visibility and rerun the failed jobs.
+Resolve scan or smoke-test failures before approving the protected promotion job. A release is
+successful only after every promoted reference passes anonymous pulls on both architectures.
+
+Reproduce a fresh user's download without changing the operator's Docker login:
+
+```bash
+bash scripts/sandbox/check-public-images.sh --pull \
+  ghcr.io/alysisai/alysis-sandbox:dev \
+  ghcr.io/alysisai/alysis-sandbox:server
+alysis sandbox doctor --smoke
+```
+
+The script uses an empty temporary Docker credential configuration. Without `--pull`, it checks
+public manifests and platform support without downloading image layers. Do not close an image
+availability issue based only on a successful build or an authenticated pull.
+
+### Image security maintenance
+
+Refresh affected version pins and their checksums together with the Python image digest and
+Debian snapshot. Upgrade inherited Debian packages against that snapshot as well as installing
+new packages. Python and `venv` already come from the Python base image. Node's bundled npm can
+lag security fixes, so npm has its own version and verified distribution checksum.
+
+HIGH/CRITICAL findings remain blocking, including unfixed findings. Review retained reports from
+both architectures; a reduction in findings is not a passing scan. Exceptions require evidence
+that the vulnerable code does not apply to the image, with the scope and rationale documented.
+Do not blanket-ignore unfixed findings or remove scanner metadata to make an image pass.
+
+The Docker image's Bubblewrap package receives updates through the Debian snapshot. Native Linux
+Bubblewrap installations use the host package and receive updates through the host package manager.
 
 ## Failed releases
 

--- a/scripts/sandbox/Dockerfile
+++ b/scripts/sandbox/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-ARG PYTHON_IMAGE=python:3.12-slim@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9
+ARG PYTHON_IMAGE=python:3.12-slim-trixie@sha256:78387bc3881b8273120a12ebe6c1ab22b018ccc2c9adf565ae1ac9b536e184ea
 ARG VARIANT=dev
 ARG SOURCE_URL=https://github.com/AlysisAi/alysis-code
 ARG GIT_SHA=dev
@@ -16,7 +16,7 @@ ARG GIT_SHA
 ARG VERSION
 ARG SOURCE_DATE_EPOCH
 # Freeze Debian package indexes instead of resolving against a moving mirror.
-ARG DEBIAN_SNAPSHOT=20260701T000000Z
+ARG DEBIAN_SNAPSHOT=20260912T120000Z
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -37,7 +37,8 @@ RUN find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) \
           {} +; \
     printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99snapshot; \
     apt-get update; \
-    packages="bash ca-certificates curl git ripgrep build-essential python3 python3-venv tini xz-utils"; \
+    apt-get upgrade -y --no-install-recommends; \
+    packages="bash ca-certificates curl git ripgrep build-essential tini xz-utils"; \
     case "${TARGETPLATFORM:-linux/amd64}" in \
         linux/*) packages="${packages} bubblewrap" ;; \
         *) echo "Skipping bubblewrap for TARGETPLATFORM=${TARGETPLATFORM:-unknown}" ;; \
@@ -72,12 +73,14 @@ USER root
 
 ARG TARGETARCH
 # Each downloaded tool is version- and digest-pinned for both supported platforms.
-ARG NODE_VERSION=24.18.1
-ARG NODE_LINUX_AMD64_SHA256=d6c664df3f3f61458e8c277585571328522d705166723a7c7823a9253a4d15a0
-ARG NODE_LINUX_ARM64_SHA256=7201e3a09dc825bac57867c81913e2b8f0ef87d04cb9082af4cda82f6ff3d88c
-ARG GO_VERSION=1.26.4
-ARG GO_LINUX_AMD64_SHA256=1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f
-ARG GO_LINUX_ARM64_SHA256=ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768
+ARG NODE_VERSION=24.21.0
+ARG NODE_LINUX_AMD64_SHA256=fd8e59d5a511510f6a298afb548f18c7d2b1be404d8b4a27d94fbe49f56cb2d6
+ARG NODE_LINUX_ARM64_SHA256=6ad1325edbdb5649c379b75a237147a666c95d4f9ae8d340fef2d1575d289ad2
+ARG NPM_VERSION=11.19.1
+ARG NPM_SHA256=9f58bff01604cb1b14008fef14dceb14d836a49225e45c6c2e37de3be3e707f0
+ARG GO_VERSION=1.26.8
+ARG GO_LINUX_AMD64_SHA256=d0f743b33e8d8945e6b1f432edd15785c70507121d6e2a723b21285eddf8b57b
+ARG GO_LINUX_ARM64_SHA256=211ffced9dcb9633a55eac6364816ec0ddd951389a740e88fa8b3337971bdda0
 ARG RUSTUP_VERSION=1.28.2
 ARG RUSTUP_LINUX_AMD64_SHA256=20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c
 ARG RUSTUP_LINUX_ARM64_SHA256=e3853c5a252fca15252d07cb23a1bdd9377a8c6f3efa01531109281ae47f841c
@@ -115,6 +118,17 @@ RUN case "${TARGETARCH:-amd64}" in \
     tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1; \
     rm /tmp/node.tar.xz; \
     node --version; \
+    npm --version
+
+# Node's bundled npm can lag npm security releases. Replace the complete,
+# verified distribution so old vendored dependencies are not left in the image.
+RUN curl --proto '=https' --tlsv1.2 -fsSLo /tmp/npm.tgz \
+        "https://registry.npmjs.org/npm/-/npm-${NPM_VERSION}.tgz"; \
+    echo "${NPM_SHA256}  /tmp/npm.tgz" | sha256sum -c -; \
+    rm -rf /usr/local/lib/node_modules/npm; \
+    mkdir -p /usr/local/lib/node_modules/npm; \
+    tar -xzf /tmp/npm.tgz -C /usr/local/lib/node_modules/npm --strip-components=1; \
+    rm /tmp/npm.tgz; \
     npm --version
 
 RUN case "${TARGETARCH:-amd64}" in \
@@ -164,7 +178,7 @@ USER root
 WORKDIR /opt/alysis
 # The digest is an official multi-platform uv image; the lockfile supplies hashes
 # for all Python runtime and build dependencies.
-COPY --from=ghcr.io/astral-sh/uv@sha256:2381d6aa60c326b71fd40023f921a0a3b8f91b14d5db6b90402e65a635053709 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv@sha256:b485bd65cc2cf1c9a93b3554012c9c3778cf7b1b5fd3d3096ce9e1226c97e1e6 /uv /usr/local/bin/uv
 COPY pyproject.toml uv.lock README.md /opt/alysis/
 COPY src /opt/alysis/src
 ENV UV_LINK_MODE=copy \

--- a/scripts/sandbox/README.md
+++ b/scripts/sandbox/README.md
@@ -7,6 +7,8 @@ for shell execution, verification, and server workers when Docker is selected.
 
 - `Dockerfile` builds the supported `base`, `dev`, and `server` variants through
   the `VARIANT` build argument.
+- `check-public-images.sh` checks anonymous manifest access and both supported
+  architectures; `--pull` also downloads image layers without reusing credentials.
 
 ## Scope
 
@@ -21,12 +23,14 @@ attestations as described in the sandbox guide.
 
 - Debian repositories use a dated snapshot, and the Python base and uv helper
   images are digest-pinned.
-- Node, Go, and rustup downloads are version-pinned and SHA-256 verified for
+- Node, npm, Go, and rustup downloads are version-pinned and SHA-256 verified for
   both `linux/amd64` and `linux/arm64`; the Rust toolchain is an exact version.
 - The server variant installs from `uv.lock` with network downloads of a
   replacement Python interpreter disabled.
 - Release candidates are scanned and runtime-smoked on both architectures
   before any moving or release alias is promoted.
+- Public candidate access is checked before promotion, and every promoted alias
+  must pass anonymous pulls. Failed candidate scans retain their SARIF artifacts.
 
 Changing a pinned version requires changing its matching digest in the same
 review and passing the sandbox release-contract tests.

--- a/scripts/sandbox/check-public-images.sh
+++ b/scripts/sandbox/check-public-images.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Verify the same unauthenticated access required by a fresh Alysis installation.
+set -euo pipefail
+
+pull=false
+if [[ "${1:-}" == "--pull" ]]; then
+  pull=true
+  shift
+fi
+if (( $# == 0 )); then
+  echo "Usage: bash check-public-images.sh [--pull] IMAGE[:TAG|@DIGEST] ..." >&2
+  exit 2
+fi
+
+# Do not log out the caller or reuse their registry credentials.
+public_config="$(mktemp -d)"
+trap 'rm -rf -- "${public_config}"' EXIT
+
+for image in "$@"; do
+  if ! docker --config "${public_config}" manifest inspect "${image}" > "${public_config}/manifest.json"; then
+    echo "Cannot download ${image} anonymously. Check that the package and reference exist, the package visibility is public, and the registry is reachable." >&2
+    exit 1
+  fi
+  if ! jq -e '
+    [.manifests[]?.platform | select(.os == "linux") | .architecture] as $architectures
+    | ($architectures | index("amd64")) != null
+      and ($architectures | index("arm64")) != null
+  ' "${public_config}/manifest.json" > /dev/null; then
+    echo "${image} must contain both linux/amd64 and linux/arm64 images." >&2
+    exit 1
+  fi
+  if [[ "${pull}" == "true" ]]; then
+    docker --config "${public_config}" pull --platform linux/amd64 "${image}"
+    docker --config "${public_config}" pull --platform linux/arm64 "${image}"
+  fi
+  echo "Public image verified: ${image} (linux/amd64, linux/arm64)"
+done

--- a/tests/test_sandbox_image_release_contract.py
+++ b/tests/test_sandbox_image_release_contract.py
@@ -179,6 +179,8 @@ def test_docker_toolchains_and_external_images_are_immutable_inputs() -> None:
     assert re.search(r"ARG NODE_VERSION=\d+\.\d+\.\d+", dockerfile)
     assert re.search(r"ARG NODE_LINUX_AMD64_SHA256=[0-9a-f]{64}", dockerfile)
     assert re.search(r"ARG NODE_LINUX_ARM64_SHA256=[0-9a-f]{64}", dockerfile)
+    assert re.search(r"ARG NPM_VERSION=\d+\.\d+\.\d+", dockerfile)
+    assert re.search(r"ARG NPM_SHA256=[0-9a-f]{64}", dockerfile)
     assert re.search(r"ARG GO_LINUX_AMD64_SHA256=[0-9a-f]{64}", dockerfile)
     assert re.search(r"ARG GO_LINUX_ARM64_SHA256=[0-9a-f]{64}", dockerfile)
     assert re.search(r"ARG RUSTUP_LINUX_AMD64_SHA256=[0-9a-f]{64}", dockerfile)

--- a/tests/test_sandbox_public_images.py
+++ b/tests/test_sandbox_public_images.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "sandbox" / "check-public-images.sh"
+
+
+@pytest.fixture
+def docker_stub(tmp_path: Path):
+    if not shutil.which("bash") or not shutil.which("jq") or sys.platform == "win32":
+        pytest.skip("public image checks require Bash and jq")
+    executable = tmp_path / "docker"
+    executable.write_text(
+        f"#!{sys.executable}\n"
+        "import json, os, pathlib, sys\n"
+        "args = sys.argv[1:]\n"
+        "assert args[0] == '--config'\n"
+        "config = pathlib.Path(args[1])\n"
+        "with open(os.environ['SANDBOX_TEST_LOG'], 'a') as log:\n"
+        "    log.write(json.dumps({'args': args, 'credentials': (config / 'config.json').exists()}) + '\\n')\n"
+        "if args[2] == os.environ.get('SANDBOX_TEST_FAIL_COMMAND'):\n"
+        "    sys.exit(1)\n"
+        "if args[2] == 'manifest':\n"
+        "    print(os.environ['SANDBOX_TEST_MANIFEST'])\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    caller_config = tmp_path / "caller-config"
+    caller_config.mkdir()
+    (caller_config / "config.json").write_text('{"auths": {}}', encoding="utf-8")
+    log = tmp_path / "docker-calls.jsonl"
+    env = {
+        **os.environ,
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+        "DOCKER_CONFIG": str(caller_config),
+        "SANDBOX_TEST_LOG": str(log),
+        "SANDBOX_TEST_MANIFEST": json.dumps(
+            {
+                "manifests": [
+                    {"platform": {"os": "linux", "architecture": arch}}
+                    for arch in ("amd64", "arm64")
+                ]
+            }
+        ),
+    }
+    return env, log, caller_config
+
+
+def test_public_check_uses_empty_credentials_and_pulls_each_platform(docker_stub) -> None:
+    env, log, caller_config = docker_stub
+    refs = ["ghcr.io/example/sandbox:dev", "ghcr.io/example/sandbox:server"]
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--pull", *refs], env=env, capture_output=True, text=True
+    )
+
+    assert result.returncode == 0, result.stderr
+    calls = [json.loads(line) for line in log.read_text().splitlines()]
+    assert all(not call["credentials"] for call in calls)
+    assert all(call["args"][1] != str(caller_config) for call in calls)
+    assert (caller_config / "config.json").read_text() == '{"auths": {}}'
+    assert [call["args"][2:] for call in calls] == [
+        command
+        for ref in refs
+        for command in (
+            ["manifest", "inspect", ref],
+            ["pull", "--platform", "linux/amd64", ref],
+            ["pull", "--platform", "linux/arm64", ref],
+        )
+    ]
+    assert not Path(calls[0]["args"][1]).exists()
+
+
+@pytest.mark.parametrize("command", ["manifest", "pull"])
+def test_registry_or_layer_download_failure_cannot_report_success(docker_stub, command) -> None:
+    env, _, _ = docker_stub
+    env["SANDBOX_TEST_FAIL_COMMAND"] = command
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--pull", "ghcr.io/example/sandbox:dev"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "Public image verified" not in result.stdout
+
+
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        {"manifests": [{"platform": {"os": "linux", "architecture": "amd64"}}]},
+        {"manifests": [{"platform": {"os": "linux", "architecture": "arm64"}}]},
+        {"schemaVersion": 2, "layers": []},
+        {},
+    ],
+)
+def test_incomplete_platform_manifest_is_rejected(docker_stub, manifest) -> None:
+    env, _, _ = docker_stub
+    env["SANDBOX_TEST_MANIFEST"] = json.dumps(manifest)
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "ghcr.io/example/sandbox:dev"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "must contain both" in result.stderr
+
+
+def test_release_checks_public_access_before_promotion_and_pulls_before_success() -> None:
+    workflow = yaml.safe_load((ROOT / ".github/workflows/sandbox-image.yml").read_text())
+    jobs = workflow["jobs"]
+    assert "verify-candidates" in jobs["promote"]["needs"]
+    verification = jobs["verify-candidates"]
+    assert verification["permissions"]["packages"] == "read"
+    checks = [
+        step for step in verification["steps"] if "check-public-images.sh" in step.get("run", "")
+    ]
+    assert len(checks) == 1
+    assert "if" not in checks[0] and "continue-on-error" not in checks[0]
+    steps = jobs["promote"]["steps"]
+    promotion = next(
+        i for i, step in enumerate(steps) if "imagetools create" in step.get("run", "")
+    )
+    public_pull = next(
+        i for i, step in enumerate(steps) if "check-public-images.sh --pull" in step.get("run", "")
+    )
+    summary = next(i for i, step in enumerate(steps) if step["name"] == "Write promotion summary")
+    assert promotion < public_pull < summary
+    assert "if" not in steps[public_pull] and "continue-on-error" not in steps[public_pull]
+
+
+@pytest.mark.parametrize(
+    ("rules", "expected_success"),
+    [
+        ([], False),
+        ([{"type": "wait_timer", "wait_timer": 1}], False),
+        ([{"type": "required_reviewers", "prevent_self_review": True, "reviewers": []}], False),
+        (
+            [
+                {
+                    "type": "required_reviewers",
+                    "prevent_self_review": False,
+                    "reviewers": [{"id": 1}],
+                }
+            ],
+            False,
+        ),
+        (
+            [{"type": "required_reviewers", "prevent_self_review": True, "reviewers": [{"id": 1}]}],
+            True,
+        ),
+    ],
+)
+def test_release_environment_requires_an_independent_reviewer(
+    tmp_path: Path, docker_stub, rules, expected_success: bool
+) -> None:
+    env, _, _ = docker_stub
+    fake_gh = tmp_path / "gh"
+    fake_gh.write_text(
+        f"#!{sys.executable}\nimport os\nprint(os.environ['SANDBOX_TEST_ENVIRONMENT'])\n",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+    env["GITHUB_REPOSITORY"] = "example/sandbox"
+    env["SANDBOX_TEST_ENVIRONMENT"] = json.dumps({"protection_rules": rules})
+    workflow = yaml.safe_load((ROOT / ".github/workflows/sandbox-image.yml").read_text())
+    job = workflow["jobs"]["validate-source"]
+    step = next(
+        step for step in job["steps"] if step["name"] == "Check the release approval environment"
+    )
+    assert "if" not in step and "continue-on-error" not in step
+    assert workflow["jobs"]["build-verify-candidate"]["needs"] == "validate-source"
+    result = subprocess.run(
+        ["bash", "-c", step["run"]], cwd=tmp_path, env=env, capture_output=True, text=True
+    )
+    assert (result.returncode == 0) == expected_success


### PR DESCRIPTION
## Summary

Fresh installations cannot pull the documented sandbox images anonymously. The release workflow now checks public candidate access before promotion and anonymously pulls every promoted alias on both architectures before reporting success; the image dependencies and recovery instructions are also refreshed. This is a draft because vulnerability scans still block publication and repository/package configuration remains necessary.

## Changes

- Check that `sandbox-release` has independent reviewers before building release candidates.
- Verify anonymous manifest access with an empty temporary Docker credential configuration, then verify both-platform pulls after promotion.
- Run the ARM64 scan even when the AMD64 scan fails, and retain failed candidate scan artifacts.
- Refresh the pinned Python/Debian base, Bubblewrap through Debian updates, Node, npm, Go, and uv. Verify npm's complete distribution separately from Node; remove the redundant Debian Python installation while preserving Python/venv from the base image.
- Document first publication, package visibility and Actions access, moving-tag promotion, and security maintenance.

## Test plan

- [x] 142 focused sandbox, workflow, background-runner, CLI, and documentation tests passed.
- [x] All 27 affected workflow/public-access tests passed again after the final workflow uv update.
- [x] Repository Ruff lint and format checks, actionlint, and `git diff --check` passed.
- [x] Built and smoke-tested base/dev/server on AMD64 and ARM64: non-root, network disabled, all capabilities dropped, no-new-privileges, read-only root, writable temporary storage. Verified Python/venv/pip, C compilation, toolchains, and the server CLI.
- [x] Strict Docker `alysis sandbox doctor --smoke` passed on macOS with the local images.
- [x] The anonymous helper pulled both architectures of a real public Python image and rejected the inaccessible Alysis GHCR reference.
- [ ] Trivy release gate: all six images still report 137 HIGH and 13 CRITICAL package findings with Trivy 0.74.0 and the 2026-09-12 07:04 UTC database.
- [ ] Public Alysis images published and anonymously pullable.

## Linked issues

Refs #11. Leave it open until the actual public `:dev` and `:server` images can be downloaded.

## Notes for reviewers

The HIGH/CRITICAL policy, including unfixed findings, remains blocking. No vulnerability exceptions were added. Raw counts include duplicate package reports: deduplication by Debian source package/CVE gives 55 kernel findings attributed to headers, 13 findings already resolved in the installed versions according to newer Debian advisories, and 14 non-kernel findings still open upstream. For example, Debian marks the installed Perl fix for [CVE-2026-13221](https://security-tracker.debian.org/tracker/CVE-2026-13221) resolved, while [Expat CVE-2026-76956](https://security-tracker.debian.org/tracker/CVE-2026-76956) remains open. Refresh the scanner database and complete applicability/patch review before release; these observations do not authorize ignoring all remaining findings.

A repository administrator must configure `sandbox-release`, and the package owner must establish public visibility and repository Actions access. After reviewed changes and passing checks, use the manual release command in `docs/RELEASING.md` with `publish_moving_tags=true`. Native Linux Bubblewrap runtime isolation was not tested on this macOS host; no native-backend code changed.
